### PR TITLE
Added function to show a list of chatrooms

### DIFF
--- a/lib/chat_app_web/controllers/room_controller.ex
+++ b/lib/chat_app_web/controllers/room_controller.ex
@@ -1,0 +1,9 @@
+defmodule ChatAppWeb.RoomController do
+  use ChatAppWeb, :controller
+  alias ChatApp.Room
+  alias ChatApp.Repo
+  def index(conn, _params) do
+    rooms = Room |> Repo.all
+    render(conn, "index.html", rooms: rooms)
+  end
+end

--- a/lib/chat_app_web/router.ex
+++ b/lib/chat_app_web/router.ex
@@ -20,6 +20,7 @@ defmodule ChatAppWeb.Router do
     get "/", PageController, :new
     # get "/:name/chat", PageController, :enter
     get "/chat", PageController, :enter
+    resources "/rooms", RoomController, only: [:index]
   end
 
   # Other scopes may use custom stacks.

--- a/lib/chat_app_web/templates/room/index.html.eex
+++ b/lib/chat_app_web/templates/room/index.html.eex
@@ -1,0 +1,20 @@
+<h1> All Rooms </h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Room Name</th>
+      <th>Room Description</th>
+    </tr>
+  </thead>
+  <tbody>
+  <%= for room <- @rooms do %>
+    <tr>
+      <td><%= room.name %></td>
+      <td><%= room.description%></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>
+
+

--- a/lib/chat_app_web/views/room_view.ex
+++ b/lib/chat_app_web/views/room_view.ex
@@ -1,0 +1,3 @@
+defmodule ChatAppWeb.RoomView do
+  use ChatAppWeb, :view
+end


### PR DESCRIPTION
# チャットルームを一覧で表示するページを追加
- /roomsにアクセスすることでroomsテーブルの中身（ルーム名とルームの概要）を順々に表示する
  - この画面への導線は未実装
  - とりあえずindexアクションのみ実装
  - ユーザ名を入力->この画面へ遷移する予定
- この画面から各チャットルームに入室するイメージ
