### PR TITLE
Separated chat content by each chat room

### DIFF
--- a/assets/js/socket.js
+++ b/assets/js/socket.js
@@ -56,7 +56,8 @@ socket.connect()
 
 // Now that you are connected, you can join channels with a topic:
 // let channel = socket.channel("topic:subtopic", {})
-let channel = socket.channel("room:lobby", {})
+let roomId = document.querySelector("#room-id").value
+let channel = socket.channel("room:" + roomId, {})
 let chatInput = document.querySelector("#chat-input")
 let messagesContainer = document.querySelector("#messages")
 // let userNameInput = document.querySelector("#user-name")

--- a/lib/chat_app_web/channels/room_channel.ex
+++ b/lib/chat_app_web/channels/room_channel.ex
@@ -1,7 +1,7 @@
 defmodule ChatAppWeb.RoomChannel do
   use Phoenix.Channel
 
-  def join("room:lobby", _message, socket) do
+  def join("room:" <> subtopic, _message, socket) do
   {:ok, socket}
   end
   def join("room:" <> _private_room_id, _params, _socket) do

--- a/lib/chat_app_web/controllers/room_controller.ex
+++ b/lib/chat_app_web/controllers/room_controller.ex
@@ -11,8 +11,8 @@ defmodule ChatAppWeb.RoomController do
     render(conn, "index.html", rooms: rooms, username: name)
   end
   def show(conn, %{"id" => id, "name" => name}) do
-    room = Room |> Repo.get(id)
-    render(conn, "chatroom.html", room: room, name: name)
+    # room = Room |> Repo.get(id)
+    render(conn, "chatroom.html", room_id: id, name: name)
   end
   def new(conn, %{"name" => name}) do
     changeset = Room.changeset(%Room{}, %{})

--- a/lib/chat_app_web/templates/room/chatroom.html.eex
+++ b/lib/chat_app_web/templates/room/chatroom.html.eex
@@ -1,3 +1,4 @@
 <div id="messages"></div>
 <input id="chat-input" type="text"></input>
 <input id="username", type="hidden", value=<%= @name %>></input>
+<input id="room-id", type="hidden", value=<%= @room_id%>></input>


### PR DESCRIPTION
## 機能概要
すべてのチャットルームでチャット内容を共通で保持していたが、それをチャットルームごとで分ける実装を追加。Aというチャット部屋とBというチャット部屋が独立するようになった

## 技術的変更点概要
- RoomControllerのshowアクションで不要なroom情報を渡していたため削除し、roomを分けるために必要なidのみを渡すように変更
- room_idをinputタグのパラメータとしてsocket.js側で受け取れるようにした
- join可能なroom名を"room: hobby"から"room"+任意の文字列に変更
  - subtopicという変数は任意の文字列を受取可能