### PR TITLE
enable to store chat content to db

### DIFF
--- a/assets/js/socket.js
+++ b/assets/js/socket.js
@@ -57,25 +57,28 @@ socket.connect()
 // Now that you are connected, you can join channels with a topic:
 // let channel = socket.channel("topic:subtopic", {})
 let roomId = document.querySelector("#room-id").value
-let channel = socket.channel("room:" + roomId, {})
+let channel = socket.channel("room:" + roomId, {room_id: roomId})
+// let channel = socket.channel("room:hoge", {})
 let chatInput = document.querySelector("#chat-input")
 let messagesContainer = document.querySelector("#messages")
 // let userNameInput = document.querySelector("#user-name")
 let userNameInput = document.querySelector("#username")
 
 chatInput.addEventListener("keypress", event => {
-  if(event.keyCode == 13) {
+  if(event.keyCode == 13 && chatInput.value.length > 0) {
     let message = '( ' + userNameInput.value + ' ) : ' + chatInput.value
-    channel.push("new_msg", {body: message})
+    channel.push("new_msg", {body: message, room_id: roomId})
     chatInput.value = ""
   }
 })
 
 channel.on("new_msg", payload => {
   let messageItem = document.createElement("li")
-  var date = new Date();
-  messageItem.innerText = `[${date.getMonth()+1 + '月' + date.getDate() + '日'
-    + date.getHours() + '時' + date.getMinutes() + '分'}] ${payload.body}`
+  // var date = new Date();
+  // messageItem.innerText = `[${date.getMonth()+1 + '月' + date.getDate() + '日'
+  //   + date.getHours() + '時' + date.getMinutes() + '分'}] ${payload.body}`
+  // messagesContainer.appendChild(messageItem)
+  messageItem.innerText = `${payload.body}`
   messagesContainer.appendChild(messageItem)
 })
 

--- a/lib/chat_app/message.ex
+++ b/lib/chat_app/message.ex
@@ -1,0 +1,21 @@
+defmodule ChatApp.Message do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "messages" do
+    field :message, :string
+    belongs_to :room, ChatApp.Room
+    timestamps()
+  end
+
+  @doc false
+  def changeset(message, attrs) do
+    message
+    |> cast(attrs, [:message])
+    |> validate_required([:message])
+  end
+
+  def get_room_info(id) do
+    ChatApp.Repo.get(ChatApp.Room, id) |> ChatApp.Repo.preload(:messages)
+  end
+end

--- a/lib/chat_app/room.ex
+++ b/lib/chat_app/room.ex
@@ -5,7 +5,7 @@ defmodule ChatApp.Room do
   schema "rooms" do
     field :description, :string
     field :name, :string
-
+    has_many :messages, ChatApp.Message
     timestamps()
   end
 

--- a/lib/chat_app_web/channels/room_channel.ex
+++ b/lib/chat_app_web/channels/room_channel.ex
@@ -1,15 +1,28 @@
 defmodule ChatAppWeb.RoomChannel do
   use Phoenix.Channel
+  require Logger
 
-  def join("room:" <> subtopic, _message, socket) do
-  {:ok, socket}
+  def join("room:" <> room_id, %{"room_id" => room_id}, socket) do
+    Logger.debug room_id
+    send(self(), {:after_join, room_id})
+    {:ok, socket}
   end
-  def join("room:" <> _private_room_id, _params, _socket) do
-    {:error, %{reason: "unauthorized"}}
-  end
-
-  def handle_in("new_msg", %{"body" => body}, socket) do
+  def handle_in("new_msg", %{"body" => body, "room_id" => room_id}, socket) do
+    Ecto.build_assoc(ChatApp.Room |> ChatApp.Repo.get(room_id), :messages, %{message: body})
+    |> ChatApp.Repo.insert
     broadcast!(socket, "new_msg", %{body: body})
     {:noreply, socket}
+  end
+
+  def handle_info({:after_join, room_id}, socket) do
+    ChatApp.Message.get_room_info(room_id).messages
+    |> Enum.each(fn msg -> push(socket, "new_msg", %{
+      body: msg.message
+    }) end)
+    {:noreply, socket}
+  end
+
+  defp authorized?(_payload) do
+    true
   end
 end

--- a/lib/chat_app_web/controllers/room_controller.ex
+++ b/lib/chat_app_web/controllers/room_controller.ex
@@ -11,7 +11,6 @@ defmodule ChatAppWeb.RoomController do
     render(conn, "index.html", rooms: rooms, username: name)
   end
   def show(conn, %{"id" => id, "name" => name}) do
-    # room = Room |> Repo.get(id)
     render(conn, "chatroom.html", room_id: id, name: name)
   end
   def new(conn, %{"name" => name}) do

--- a/priv/repo/migrations/20190515022943_create_messages.exs
+++ b/priv/repo/migrations/20190515022943_create_messages.exs
@@ -1,0 +1,13 @@
+defmodule ChatApp.Repo.Migrations.CreateMessages do
+  use Ecto.Migration
+
+  def change do
+    create table(:messages) do
+      add :name, :string
+      add :message, :string
+
+      timestamps()
+    end
+
+  end
+end

--- a/priv/repo/migrations/20190515030728_remove_name_column.exs
+++ b/priv/repo/migrations/20190515030728_remove_name_column.exs
@@ -1,0 +1,9 @@
+defmodule ChatApp.Repo.Migrations.RemoveNameColumn do
+  use Ecto.Migration
+
+  def change do
+    alter table(:messages) do
+      remove :name
+    end
+  end
+end

--- a/priv/repo/migrations/20190515055037_message_belongs_to_user.exs
+++ b/priv/repo/migrations/20190515055037_message_belongs_to_user.exs
@@ -1,0 +1,9 @@
+defmodule ChatApp.Repo.Migrations.MessageBelongsToUser do
+  use Ecto.Migration
+
+  def change do
+    alter table(:messages) do
+      add :room_id, references(:rooms)
+    end
+  end
+end


### PR DESCRIPTION
#14 チャット内容の保持
## 機能概要
チャットを送信したときにdbへ保存できるようになった
チャットルームへ入室したときにそのルームに紐付いたチャット内容を引っ張って表示する
リロードしてもチャット内容は消えない
## 技術的変更点
- messageモデルの追加
- messageモデルとroomモデル感のassociationを定義
  - belongs_toとhas_many