### PR TITLE
Fix bug when deleting chatroom

### DIFF
--- a/priv/repo/migrations/20190515082726_message_column_update.exs
+++ b/priv/repo/migrations/20190515082726_message_column_update.exs
@@ -1,0 +1,10 @@
+defmodule ChatApp.Repo.Migrations.MessageColumnUpdate do
+  use Ecto.Migration
+
+  def change do
+    alter table(:messages) do
+      remove :room_id
+      add :room_id, references(:rooms, on_delete: :delete_all)
+    end
+  end
+end


### PR DESCRIPTION
## 機能概要
モデル間のassociationによって削除ができないバグの修正
## 技術的変更点
messageモデルのroom_idへon_delete: :delete_allオプションを渡すことで、親のroomが削除されたことに連動してmessageモデルが削除されるようになった