### PR TITLE
Show send message when sending image

### DIFF
--- a/assets/js/socket.js
+++ b/assets/js/socket.js
@@ -61,6 +61,7 @@ let chatInput = document.querySelector("#chat-input")
 let messagesContainer = document.querySelector("#messages")
 let imageInput = document.querySelector("#image-input")
 let userNameInput = document.querySelector("#username")
+let imageButton = document.querySelector("#image-button")
 
 chatInput.addEventListener("keypress", event => {
   if(event.keyCode == 13 && chatInput.value.length > 0) {
@@ -69,6 +70,14 @@ chatInput.addEventListener("keypress", event => {
     channel.push("new_msg", {body: message, room_id: roomId, image: image})
     chatInput.value = ""
   }
+})
+
+imageButton.addEventListener("click", event => {
+  // if(imageInput.value.length() > 0) {
+    let message = userNameInput.value + "さん が画像を送信したよ."
+    let image = "null"
+    channel.push("new_msg", {body: message, room_id: roomId, image: image})
+  // }
 })
 
 channel.on("new_msg", payload => {

--- a/lib/chat_app/message.ex
+++ b/lib/chat_app/message.ex
@@ -6,6 +6,7 @@ defmodule ChatApp.Message do
   schema "messages" do
     field :message, :string
     field :image, ChatApp.ImageUploader.Type
+    # field :image, :string
     belongs_to :room, ChatApp.Room
     timestamps()
   end
@@ -14,7 +15,7 @@ defmodule ChatApp.Message do
   def changeset(message, attrs) do
     message
     |> cast(attrs, [:message])
-    |> validate_required([:message])
+    # |> validate_required([:message])
     |> cast_attachments(attrs, [:image])
   end
 

--- a/lib/chat_app_web/channels/room_channel.ex
+++ b/lib/chat_app_web/channels/room_channel.ex
@@ -14,11 +14,6 @@ defmodule ChatAppWeb.RoomChannel do
     {:noreply, socket}
   end
 
-  def handle_in("new_img", %{"body" => body, "image" => image}, socket) do
-    broadcast!(socket, "new_img", %{body: body, image: image})
-    {:noreply, socket}
-  end
-
   def handle_info({:after_join, room_id}, socket) do
     ChatApp.Message.get_room_info(room_id).messages
     |> Enum.each(fn msg -> push(socket, "new_msg", %{

--- a/lib/chat_app_web/controllers/message_controller.ex
+++ b/lib/chat_app_web/controllers/message_controller.ex
@@ -5,7 +5,7 @@ defmodule ChatAppWeb.MessageController do
   alias ChatApp.Repo
   def create(conn, %{"message" => message_params, "name" => name, "id" => room_id}) do
     changeset = Ecto.build_assoc(ChatApp.Room |> ChatApp.Repo.get(room_id), :messages)
-    |> Message.changeset(%{image: message_params["image"], message: message_params["text"]})
+    |> Message.changeset(%{image: message_params["image"], message: " "})
     case Repo.insert(changeset) do
       {:ok, message} ->
         conn

--- a/lib/chat_app_web/templates/room/chatroom.html.eex
+++ b/lib/chat_app_web/templates/room/chatroom.html.eex
@@ -1,14 +1,13 @@
 <div class="chatroom">
   <div id="messages"></div>
   <input id="chat-input" type="text" placeholder="入力してenterで送信！"></input>
-  <!-- <input id="image-input" type="file"></input> -->
   <input id="username", type="hidden", value=<%= @name %>></input>
   <input id="room-id", type="hidden", value=<%= @room_id%>></input>
 </div>
 <%= form_for @changeset, Routes.message_path(@conn, :create, @name, @room_id), [multipart: true], fn f -> %>
-  <%= file_input f, :image, required: true %>
+  <%= file_input f, :image, required: true, id: "image-input" %>
   <%= error_tag f, :image %>
-  <%= text_input f, :text, value: "( " <> @name <> "さん ) : ", type: "hidden" %>
+  <%= text_input f, :text, value: "", type: "hidden" %>
   <%= text_input f, :room_id, value: @room_id, type: "hidden" %>
-  <%= submit "画像を送信", class: "btn btn-primary" %>
+  <%= submit "画像を送信", class: "btn btn-primary", id: "image-button" %>
 <% end %>


### PR DESCRIPTION
# 機能概要
画像を送信時に「画像が送信されました」という旨を伝える表示文言を追加
（本当は画像の非同期通信をやりたかったが実装に時間がかかりそうなので、送信した文言を追記してユーザのリロードを促すスタイルでとりあえず実装）

## 技術的変更点
- 画像送信時にmessageの空白を許容しないといけないためバリデーションをしないように設定
- 送信文言の追加にはbuttonのclickイベントでメッセージをappendするようにした