### PR TITLE
Improve message when sending image in chatroom

### DIFF
--- a/assets/js/socket.js
+++ b/assets/js/socket.js
@@ -75,8 +75,11 @@ chatInput.addEventListener("keypress", event => {
 imageButton.addEventListener("click", event => {
   // if(imageInput.value.length() > 0) {
     let message = userNameInput.value + "さん が画像を送信したよ."
+    message += "リロードしてみてね."
+    let saveMessage = '( ' + userNameInput.value + 'さん ) : '
+    saveMessage += "画像を送信しました"
     let image = "null"
-    channel.push("new_msg", {body: message, room_id: roomId, image: image})
+    channel.push("new_img", {body: message, room_id: roomId, image: image, save_message: saveMessage})
   // }
 })
 

--- a/lib/chat_app_web/channels/room_channel.ex
+++ b/lib/chat_app_web/channels/room_channel.ex
@@ -14,6 +14,14 @@ defmodule ChatAppWeb.RoomChannel do
     {:noreply, socket}
   end
 
+  def handle_in("new_img", %{"body" => body, "room_id" => room_id, "image" => image, "save_message" => save_message}, socket) do
+    changeset = Ecto.build_assoc(ChatApp.Room |> ChatApp.Repo.get(room_id), :messages)
+    |> ChatApp.Message.changeset(%{image: image, message: save_message})
+    |> ChatApp.Repo.insert
+    broadcast!(socket, "new_msg", %{body: body, image: image})
+    {:noreply, socket}
+  end
+
   def handle_info({:after_join, room_id}, socket) do
     ChatApp.Message.get_room_info(room_id).messages
     |> Enum.each(fn msg -> push(socket, "new_msg", %{


### PR DESCRIPTION
# 機能変更
画像の送信時に以下のメッセージを追加した
![image](https://user-images.githubusercontent.com/49419925/58393279-0aacb680-8079-11e9-94b6-1c52095f3bd8.png)
リロードするとこのメッセージは消え以下のように表示される
![image](https://user-images.githubusercontent.com/49419925/58393318-35970a80-8079-11e9-811f-3be1f8635e79.png)

# 技術的変更点
new_imgで発火するハンドラ（画像送信時）を定義してdbに保存するようのメッセージとフラッシュメッセージとしてチャットルームへ送信するメッセージの2つを定義