### PR TITLE
Validate about image

### DIFF
--- a/assets/js/socket.js
+++ b/assets/js/socket.js
@@ -63,6 +63,7 @@ let imageInput = document.querySelector("#image-input")
 let userNameInput = document.querySelector("#username")
 let imageButton = document.querySelector("#image-button")
 
+
 chatInput.addEventListener("keypress", event => {
   if(event.keyCode == 13 && chatInput.value.length > 0) {
     let message = '( ' + userNameInput.value + 'さん ) : ' + chatInput.value
@@ -73,14 +74,17 @@ chatInput.addEventListener("keypress", event => {
 })
 
 imageButton.addEventListener("click", event => {
-  // if(imageInput.value.length() > 0) {
-    let message = userNameInput.value + "さん が画像を送信したよ."
-    message += "リロードしてみてね."
-    let saveMessage = '( ' + userNameInput.value + 'さん ) : '
-    saveMessage += "画像を送信しました"
-    let image = "null"
-    channel.push("new_img", {body: message, room_id: roomId, image: image, save_message: saveMessage})
-  // }
+  let message = userNameInput.value + "さん が画像を送信したよ."
+  message += "リロードしてみてね."
+  let saveMessage = '( ' + userNameInput.value + 'さん ) : '
+  saveMessage += "画像を送信しました"
+  let image = "null"
+  // console.log(imageInput.value.length())
+  channel.push("new_img", {body: message, room_id: roomId, image: image, save_message: saveMessage})
+})
+
+imageInput.addEventListener("change", event => {
+  imageButton.disabled = false;
 })
 
 channel.on("new_msg", payload => {

--- a/assets/js/socket.js
+++ b/assets/js/socket.js
@@ -79,7 +79,6 @@ imageButton.addEventListener("click", event => {
   let saveMessage = '( ' + userNameInput.value + 'さん ) : '
   saveMessage += "画像を送信しました"
   let image = "null"
-  // console.log(imageInput.value.length())
   channel.push("new_img", {body: message, room_id: roomId, image: image, save_message: saveMessage})
 })
 

--- a/lib/chat_app_web/templates/room/chatroom.html.eex
+++ b/lib/chat_app_web/templates/room/chatroom.html.eex
@@ -9,5 +9,5 @@
   <%= error_tag f, :image %>
   <%= text_input f, :text, value: "", type: "hidden" %>
   <%= text_input f, :room_id, value: @room_id, type: "hidden" %>
-  <%= submit "画像を送信", class: "btn btn-primary", id: "image-button" %>
+  <%= submit "画像を送信", class: "btn btn-primary", id: "image-button", disabled: true %>
 <% end %>

--- a/lib/chat_app_web/templates/room/chatroom.html.eex
+++ b/lib/chat_app_web/templates/room/chatroom.html.eex
@@ -5,7 +5,7 @@
   <input id="room-id", type="hidden", value=<%= @room_id%>></input>
 </div>
 <%= form_for @changeset, Routes.message_path(@conn, :create, @name, @room_id), [multipart: true], fn f -> %>
-  <%= file_input f, :image, required: true, id: "image-input" %>
+  <%= file_input f, :image, required: true, id: "image-input", accept: "image/*" %>
   <%= error_tag f, :image %>
   <%= text_input f, :text, value: "", type: "hidden" %>
   <%= text_input f, :room_id, value: @room_id, type: "hidden" %>

--- a/lib/chat_app_web/uploaders/image_uploader.ex
+++ b/lib/chat_app_web/uploaders/image_uploader.ex
@@ -5,10 +5,10 @@ defmodule ChatApp.ImageUploader do
   # Include ecto support (requires package arc_ecto installed):
   # use Arc.Ecto.Definition
 
-  @versions [:original]
+  # @versions [:original]
 
   # To add a thumbnail version:
-  # @versions [:original, :thumb]
+  @versions [:original, :thumb]
 
   # Override the bucket on a per definition basis:
   # def bucket do
@@ -21,9 +21,9 @@ defmodule ChatApp.ImageUploader do
   # end
 
   # Define a thumbnail transformation:
-  # def transform(:thumb, _) do
-  #   {:convert, "-strip -thumbnail 250x250^ -gravity center -extent 250x250 -format png", :png}
-  # end
+  def transform(:thumb, _) do
+    {:convert, "-strip -thumbnail 250x250^ -gravity center -extent 250x250"}
+  end
 
   # Override the persisted filenames:
   # def filename(version, _) do


### PR DESCRIPTION
# 機能概要
- 画像を選択していないときに画像送信ボタンをインアクティブにするように変更
- 送信できるファイルをメディアタイプのものだけに限定
- 送信した写真が250x250でリサイズされるように変更
# 技術的変更点
- とくになし