### PR TITLE
Add button that enable to return to chat_index

### DIFF
--- a/assets/css/phoenix.css
+++ b/assets/css/phoenix.css
@@ -178,3 +178,20 @@ header nav a {
 .link-text a:hover {
   text-decoration: none;
 }
+
+#index-to-room {
+  font-size: 25px;
+  margin-bottom: 50px;
+  margin-top: -20px;
+  float: right;
+}
+
+#image-button {
+  font-size: 25px;
+  padding-bottom: 45px;
+  margin-left: -40px;
+}
+
+#image-input {
+  font-size: 25px;
+}

--- a/lib/chat_app_web/templates/room/chatroom.html.eex
+++ b/lib/chat_app_web/templates/room/chatroom.html.eex
@@ -11,3 +11,5 @@
   <%= text_input f, :room_id, value: @room_id, type: "hidden" %>
   <%= submit "画像を送信", class: "btn btn-primary", id: "image-button", disabled: true %>
 <% end %>
+<%= link("ルーム一覧画面へ", to: Routes.room_path(@conn, :index, @name), class: "btn btn-info", id: "index-to-room") %>
+


### PR DESCRIPTION
# 機能概要
- チャットルームに、チャットルーム一覧画面へのリンクとなるボタンを追加
- ボタンの大きさなど細かいUIの調整
# 技術的変更点
- 特になし