### PR TITLE
Improve chatapp ui

### DIFF
--- a/assets/css/phoenix.css
+++ b/assets/css/phoenix.css
@@ -168,6 +168,9 @@ header nav a {
 .chatroom {
   font-family: 'Kosugi Maru', sans-serif;
   font-size: 20px;
+  float: right;
+  width: 60%;
+  margin-left: 5%;
 }
 
 .top-page {
@@ -180,18 +183,41 @@ header nav a {
 }
 
 #index-to-room {
-  font-size: 25px;
-  margin-bottom: 50px;
-  margin-top: -20px;
-  float: right;
+  font-size: 15px;
 }
 
 #image-button {
-  font-size: 25px;
-  padding-bottom: 45px;
-  margin-left: -40px;
+  font-size: 15px;
+  margin-left: 0px;
 }
 
 #image-input {
-  font-size: 25px;
+  font-size: 15px;
+}
+
+.sidebyside {
+  content: "";
+  display: block;
+  clear: both;
+}
+
+.side-right-bar {
+  font-family: 'Kosugi Maru', sans-serif;
+  font-size: 17px;
+  float: right;
+  width: 35%;
+}
+
+table {
+  width: 100%;
+  table-layout: fixed;
+  text-align: center;
+}
+
+table td {
+  overflow-wrap: break-word;
+}
+
+.input-form {
+  margin-top: 25px;
 }

--- a/assets/js/socket.js
+++ b/assets/js/socket.js
@@ -77,7 +77,11 @@ imageButton.addEventListener("click", event => {
   let message = userNameInput.value + "さん が画像を送信したよ."
   message += "リロードしてみてね."
   let saveMessage = '( ' + userNameInput.value + 'さん ) : '
-  saveMessage += "画像を送信しました"
+  if(chatInput.value == 0){
+    saveMessage += "画像を送信しました"
+  } else {
+    saveMessage += chatInput.value
+  }
   let image = "null"
   channel.push("new_img", {body: message, room_id: roomId, image: image, save_message: saveMessage})
 })

--- a/lib/chat_app_web/controllers/room_controller.ex
+++ b/lib/chat_app_web/controllers/room_controller.ex
@@ -13,7 +13,8 @@ defmodule ChatAppWeb.RoomController do
   end
   def show(conn, %{"id" => id, "name" => name}) do
     changeset = Message.changeset(%Message{}, %{})
-    render(conn, "chatroom.html", room_id: id, name: name, changeset: changeset)
+    room = Room |> Repo.get(id)
+    render(conn, "chatroom.html", room_id: id, name: name, changeset: changeset, room: room)
   end
   def new(conn, %{"name" => name}) do
     changeset = Room.changeset(%Room{}, %{})

--- a/lib/chat_app_web/templates/room/chatroom.html.eex
+++ b/lib/chat_app_web/templates/room/chatroom.html.eex
@@ -1,15 +1,29 @@
+<div class="sidebyside">
 <div class="chatroom">
   <div id="messages"></div>
-  <input id="chat-input" type="text" placeholder="入力してenterで送信！"></input>
   <input id="username", type="hidden", value=<%= @name %>></input>
   <input id="room-id", type="hidden", value=<%= @room_id%>></input>
+  <div class="input-form">
+    <input id="chat-input" type="text" placeholder="入力してenterで送信！"></input>
+    <%= form_for @changeset, Routes.message_path(@conn, :create, @name, @room_id), [multipart: true], fn f -> %>
+      <%= file_input f, :image, required: true, id: "image-input", accept: "image/*" %>
+      <%= error_tag f, :image %>
+      <%= text_input f, :text, value: "", type: "hidden" %>
+      <%= text_input f, :room_id, value: @room_id, type: "hidden" %>
+      <%= submit "画像を送信", class: "btn btn-primary", id: "image-button", disabled: true %>
+    <% end %>
+  </div>
 </div>
-<%= form_for @changeset, Routes.message_path(@conn, :create, @name, @room_id), [multipart: true], fn f -> %>
-  <%= file_input f, :image, required: true, id: "image-input", accept: "image/*" %>
-  <%= error_tag f, :image %>
-  <%= text_input f, :text, value: "", type: "hidden" %>
-  <%= text_input f, :room_id, value: @room_id, type: "hidden" %>
-  <%= submit "画像を送信", class: "btn btn-primary", id: "image-button", disabled: true %>
-<% end %>
-<%= link("ルーム一覧画面へ", to: Routes.room_path(@conn, :index, @name), class: "btn btn-info", id: "index-to-room") %>
+<div class="side-right-bar">
+  <table class="table-default">
+    <tr>
+      <th>部屋名</th><td><%= @room.name %></td>
+    </tr>
+    <tr>
+      <th>概要</th><td><%= @room.description %></td>
+    </tr>
+  </table>
+  <%= link("ルーム一覧画面へ", to: Routes.room_path(@conn, :index, @name), class: "btn btn-info", id: "index-to-room") %>
+</div>
+</div>
 

--- a/lib/chat_app_web/templates/room/index.html.eex
+++ b/lib/chat_app_web/templates/room/index.html.eex
@@ -1,4 +1,4 @@
-<table class="table-responsive-xl table-hover">
+<table class="table-hover">
   <thead class="thead-light">
     <tr>
       <th class="table-text">部屋の名前</th>

--- a/lib/chat_app_web/templates/room/new.html.eex
+++ b/lib/chat_app_web/templates/room/new.html.eex
@@ -1,14 +1,14 @@
 <%= form_for @changeset, Routes.room_path(@conn, :create, @name), fn f -> %>
 
 <div class="form-group">
-  <label>タイトル</label>
-  <%= text_input f, :name, class: "form-control" %>
+  <label>タイトル（ 15文字以内 ）</label>
+  <%= text_input f, :name, class: "form-control", maxlength: "15" %>
   <%= error_tag f, :name%>
 </div>
 
 <div class="form-group">
-  <label>本文</label>
-  <%= textarea f, :description, class: "form-control" %>
+  <label>本文 ( 35文字以内 )</label>
+  <%= text_input f, :description, class: "form-control", maxlength: "35" %>
   <%= error_tag f, :description %>
 </div>
 


### PR DESCRIPTION
# 機能概要
- 画像とテキストデータを両方同時に送信できるようにした
- チャット画面にルーム内容の表示を追加
- 部屋を作る際に文字数の制限を追加